### PR TITLE
Makes all naive timestamps tz-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Vacation(
 )
 ```
 
+*Please note*: All datetime objects are in the `Europe/Berlin (CET/CEST)` timezone
+
 Using the async version it is easy to make multiple requests in "parallel" (not true... you know that when you are
 an asyncio enthusiast) and save a lot of time:
 

--- a/README.mdpp
+++ b/README.mdpp
@@ -42,6 +42,8 @@ Vacation(
 )
 ```
 
+*Please note*: All datetime objects are in the `Europe/Berlin (CET/CEST)` timezone
+
 Using the async version it is easy to make multiple requests in "parallel" (not true... you know that when you are
 an asyncio enthusiast) and save a lot of time:
 

--- a/ferien/const.py
+++ b/ferien/const.py
@@ -15,4 +15,4 @@ API_STATE_URL = 'https://ferien-api.de/api/v1/holidays/{state_code}'
 API_STATE_YEAR_URL = 'https://ferien-api.de/api/v1/holidays/' \
                      '{state_code}/{year}'
 
-UTC = pytz.UTC
+TZ_GERMANY = pytz.timezone("Europe/Berlin")

--- a/ferien/const.py
+++ b/ferien/const.py
@@ -1,5 +1,7 @@
 """Useful constants"""
 
+import pytz
+
 ALL_STATE_CODES = [
     "BW", "BY", "BE", "BB", "HB", "HH",
     "HE", "MV", "NI", "NW", "RP", "SL",
@@ -12,3 +14,5 @@ API_STATE_URL = 'https://ferien-api.de/api/v1/holidays/{state_code}'
 
 API_STATE_YEAR_URL = 'https://ferien-api.de/api/v1/holidays/' \
                      '{state_code}/{year}'
+
+UTC = pytz.UTC

--- a/ferien/model.py
+++ b/ferien/model.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import attr
 
-from .const import UTC
+from .const import TZ_GERMANY
 from .types import StateCode, APIItem
 
 
@@ -54,12 +54,13 @@ class Vacation:
     def _parse_date(candidate: str) -> datetime:
         # Parse iso format
         dt = datetime.strptime(candidate, '%Y-%m-%dT%H:%M')
-        # All dates from the api are UTC
-        return dt.replace(tzinfo=UTC)
+        # All dates from the api are Europe/Berlin (CET/CEST)
+        return dt.replace(tzinfo=TZ_GERMANY)
 
     @classmethod
     def from_dict(cls, dct: APIItem) -> 'Vacation':
         """Initializes the Vacation model from a dictionary instance."""
+
         return cls(
             start=cls._parse_date(dct['start']),
             end=cls._parse_date(dct['end']),

--- a/ferien/model.py
+++ b/ferien/model.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 import attr
 
+from .const import UTC
 from .types import StateCode, APIItem
 
 
@@ -49,12 +50,19 @@ class Vacation:
         converter=str
     )  # type: str
 
+    @staticmethod
+    def _parse_date(candidate: str) -> datetime:
+        # Parse iso format
+        dt = datetime.strptime(candidate, '%Y-%m-%dT%H:%M')
+        # All dates from the api are UTC
+        return dt.replace(tzinfo=UTC)
+
     @classmethod
     def from_dict(cls, dct: APIItem) -> 'Vacation':
         """Initializes the Vacation model from a dictionary instance."""
         return cls(
-            start=datetime.strptime(dct['start'], '%Y-%m-%dT%H:%M'),
-            end=datetime.strptime(dct['end'], '%Y-%m-%dT%H:%M'),
+            start=cls._parse_date(dct['start']),
+            end=cls._parse_date(dct['end']),
             year=dct['year'],
             state_code=dct['stateCode'],
             name=dct.get('name', 'none'),

--- a/ferien/util.py
+++ b/ferien/util.py
@@ -2,8 +2,24 @@
 from datetime import datetime
 from typing import Iterable, Any, Optional, cast
 
-from .const import ALL_STATE_CODES
+from .const import ALL_STATE_CODES, UTC
 from .model import Vacation
+
+
+def is_tz_aware_timestamp(dt: datetime) -> bool:
+    """Checks if the passed timestamp is tz aware or not."""
+    return dt.tzinfo is not None and dt.tzinfo.utcoffset(dt) is not None
+
+
+def make_tz_aware_timestamp(dt: Optional[datetime]) -> datetime:
+    """Make a timezone aware timestamp based on the given dt.
+    1. dt is None: datetime.now() in utc timezone
+    2. dt has timezone: Return as is
+    3. dt has no timezone: Assume that is utc and set timezone."""
+    dt = dt or datetime.now()
+    if not is_tz_aware_timestamp(dt):
+        dt = dt.replace(tzinfo=UTC)
+    return dt
 
 
 def parse_state_code(candidate: Any) -> str:
@@ -46,7 +62,7 @@ def check_vac_list(vacs: Iterable[Vacation]) -> None:
 
 
 def check_datetime(dt: Any) -> None:
-    """Checks if the argment dt is a valid datetime."""
+    """Checks if the argument dt is a valid datetime."""
     if dt and not isinstance(dt, datetime):
         raise TypeError("Argument 'dt' is expected to be of type 'datetime', "
                         "but is {}".format(type(dt)))
@@ -60,7 +76,7 @@ def find_current(vacs: Iterable[Vacation],
     check_vac_list(vacs)
     check_datetime(dt)
 
-    dt = dt or datetime.now()
+    dt = make_tz_aware_timestamp(dt)
     res = [i for i in vacs if i.start <= dt <= i.end][-1:]
     if not res:
         return None
@@ -74,7 +90,7 @@ def find_next(vacs: Iterable[Vacation],
     check_vac_list(vacs)
     check_datetime(dt)
 
-    dt = dt or datetime.now()
+    dt = make_tz_aware_timestamp(dt)
     res = sorted([i for i in vacs if i.start >= dt], key=lambda i: i.start)
     if not res:
         return None

--- a/ferien/util.py
+++ b/ferien/util.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from typing import Iterable, Any, Optional, cast
 
-from .const import ALL_STATE_CODES, UTC
+from .const import ALL_STATE_CODES, TZ_GERMANY
 from .model import Vacation
 
 
@@ -13,12 +13,12 @@ def is_tz_aware_timestamp(dt: datetime) -> bool:
 
 def make_tz_aware_timestamp(dt: Optional[datetime]) -> datetime:
     """Make a timezone aware timestamp based on the given dt.
-    1. dt is None: datetime.now() in utc timezone
+    1. dt is None: datetime.now() in german timezone
     2. dt has timezone: Return as is
-    3. dt has no timezone: Assume that is utc and set timezone."""
+    3. dt has no timezone: Assume that is german tz and set it."""
     dt = dt or datetime.now()
     if not is_tz_aware_timestamp(dt):
-        dt = dt.replace(tzinfo=UTC)
+        dt = dt.replace(tzinfo=TZ_GERMANY)
     return dt
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,9 @@ setup(
     },
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
-        'aiohttp>=3.5.0'
-        'attrs>=18.0.0'
+        'aiohttp>=3.5.0',
+        'attrs>=18.0.0',
+        'pytz>=2015.2',
         'requests>=2.0.0'
     ],
     python_requires='>=3.5',


### PR DESCRIPTION
All non-specified naive timestamps are now supposed to be in timezone `Europe/Berlin` as the vacations are for Germany. It is easier to localize this tz-ware timestamps into other timezones like UTC