### PR TITLE
Adds strptime fallback for Z remainder

### DIFF
--- a/ferien/model.py
+++ b/ferien/model.py
@@ -53,7 +53,13 @@ class Vacation:
     @staticmethod
     def _parse_date(candidate: str) -> datetime:
         # Parse iso format
-        dt = datetime.strptime(candidate, '%Y-%m-%dT%H:%M')
+        try:
+            # Date format before 2020-09-07
+            # Keep it if the Z remainder was introduced by accident
+            dt = datetime.strptime(candidate, '%Y-%m-%dT%H:%M')
+        except ValueError:
+            # Date format after 2020-09-07
+            dt = datetime.strptime(candidate, '%Y-%m-%dT%H:%MZ')
         # All dates from the api are Europe/Berlin (CET/CEST)
         return TZ_GERMANY.localize(dt)
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -17,8 +17,8 @@ DUMMY_RESP = [
       "slug": "winterferien-2017-HB"
     },
     {
-      "start": "2017-04-09T22:00",
-      "end": "2017-04-22T22:00",
+      "start": "2017-04-09T22:00Z",
+      "end": "2017-04-22T22:00Z",
       "year": 2017,
       "stateCode": "HB",
       "name": "osterferien",


### PR DESCRIPTION
It seems that the date format of the api has changed.
From `2017-01-30T00:00` to `2017-01-30T00:00Z`. Z means Zulu / GMT. But from what I can tell it is not GMT but appears still to be CET/CEST. I think it got in there by accident. So we keep the old date format in case the api rolls back the change